### PR TITLE
👷 fixing apikey revoke server crash

### DIFF
--- a/packages/api/controllers/apikey.controller.ts
+++ b/packages/api/controllers/apikey.controller.ts
@@ -60,10 +60,12 @@ export default class APIKeyController
 			return next(error);
 		}
 		if (delKey === 0)
-			throw new CustomError({
-				message: 'API Key not found',
-				statusCode: 404,
-			});
+			return next(
+				new CustomError({
+					message: 'API Key not found',
+					statusCode: 404,
+				})
+			);
 		return res.status(200).json(makeResponse({ message: 'API Key revoked' }));
 	};
 


### PR DESCRIPTION
![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![BRAVO68WEB /fix/revoke-api-key → BRAVO68WEB/shx](https://badgen.net/badge/%23101/BRAVO68WEB%20%2Ffix%2Frevoke-api-key%20%E2%86%92%20BRAVO68WEB%2Fshx/ab5afc)](https://github.com/BRAVO68WEB/shx/tree/fix/revoke-api-key) ![Commits: 1 | Files Changed: 1 | Additions: 2](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%202/dddd00) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=BRAVO68WEB&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: Bugfix

**Overview**
Fixes #100 

**Issue Number** #100

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors