### PR TITLE
Potential fix for code scanning alert no. 135: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wiki-docs-sync.yaml
+++ b/.github/workflows/wiki-docs-sync.yaml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch: # Manual dispatch
   schedule:
     - cron: '0 1 * * 0' # At 01:00 on Sunday.
+permissions:
+  contents: read
 jobs:
   update-wiki:
     runs-on: ubuntu-latest


### PR DESCRIPTION
![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) ![✏️ Draft](https://badgen.net/badge/Status/%E2%9C%8F%EF%B8%8F%20Draft/ffa933) [![BRAVO68WEB /alert-autofix-135 → BRAVO68WEB/shx](https://badgen.net/badge/%23220/BRAVO68WEB%20%2Falert-autofix-135%20%E2%86%92%20BRAVO68WEB%2Fshx/ab5afc)](https://github.com/BRAVO68WEB/shx/tree/alert-autofix-135) ![Commits: 1 | Files Changed: 1 | Additions: 2](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%202/dddd00) ![Category](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Category/f25265) ![Overview](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Overview/f25265) ![Quality Checklist](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Quality%20Checklist/f25265) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=BRAVO68WEB&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Potential fix for [https://github.com/BRAVO68WEB/shx/security/code-scanning/135](https://github.com/BRAVO68WEB/shx/security/code-scanning/135)

Add an explicit `permissions` block at the workflow root in `.github/workflows/wiki-docs-sync.yaml` so all jobs inherit least-privilege defaults. For this workflow, the minimal safe baseline is:

- `contents: read`

This addresses the CodeQL finding directly and does not change the existing job steps or action logic. Place the block after `on:` triggers and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._ 