### PR TITLE
Potential fix for code scanning alert no. 130: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-tag-pr.yaml
+++ b/.github/workflows/auto-tag-pr.yaml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   tag-pre-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag: ${{ steps.autotag.outputs.tagname }}
     steps:
@@ -18,6 +22,8 @@ jobs:
         commit_message_template: "🔖 {{number}} {{message}} (by {{author}})\nSHA: {{sha}}\n."
   github-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: tag-pre-release
     if: ${{ needs.tag-pre-release.outputs.tag }}
     steps:
@@ -29,6 +35,9 @@ jobs:
         bodyFile: ".github/LATEST_CHANGELOG.md"
   mark-issue-fixed:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
     - uses: actions/checkout@v2
     - name: Label Fixed Issues


### PR DESCRIPTION
![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) ![✏️ Draft](https://badgen.net/badge/Status/%E2%9C%8F%EF%B8%8F%20Draft/ffa933) [![BRAVO68WEB /alert-autofix-130 → BRAVO68WEB/shx](https://badgen.net/badge/%23221/BRAVO68WEB%20%2Falert-autofix-130%20%E2%86%92%20BRAVO68WEB%2Fshx/ab5afc)](https://github.com/BRAVO68WEB/shx/tree/alert-autofix-130) ![Commits: 1 | Files Changed: 1 | Additions: 9](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%209/dddd00) ![Category](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Category/f25265) ![Overview](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Overview/f25265) ![Quality Checklist](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Quality%20Checklist/f25265) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=BRAVO68WEB&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Potential fix for [https://github.com/BRAVO68WEB/shx/security/code-scanning/130](https://github.com/BRAVO68WEB/shx/security/code-scanning/130)

Add explicit `permissions` blocks so each job only gets the scopes it needs.

Best approach (without changing functionality) in `.github/workflows/auto-tag-pr.yaml`:

- Add a workflow-level baseline permission:
  - `contents: read` (minimal default for all jobs).
- Add job-level overrides where write access is required:
  - `tag-pre-release`: `contents: write` (it creates/pushes tags).
  - `github-release`: `contents: write` (it creates a GitHub release).
  - `mark-issue-fixed`: `contents: read` and `issues: write` (reads repo content and writes labels on issues/PR issues).

This preserves behavior while enforcing least privilege explicitly and resolves the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._ 